### PR TITLE
fix python tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,12 @@ project(spline)
 INCLUDE(cmake/base.cmake)
 INCLUDE(cmake/test.cmake)
 INCLUDE(cmake/python.cmake)
+INCLUDE(cmake/hpp.cmake)
 
-SET(PROJECT_ORG humanoid-path-planner)
 SET(PROJECT_NAME hpp-spline)
 SET(PROJECT_DESCRIPTION
-	 "template based classes for creating and manipulating spline and bezier curves. Comes with extra options specific to end-effector trajectories in robotics."
- )
-SET(PROJECT_URL "https://github.com/${PROJECT_ORG}/${PROJECT_NAME}")
+  "template based classes for creating and manipulating spline and bezier curves. Comes with extra options specific to end-effector trajectories in robotics."
+  )
 
 # Disable -Werror on Unix for now.
 SET(CXX_DISABLE_WERROR True)
@@ -18,24 +17,23 @@ SET(CMAKE_VERBOSE_MAKEFILE True)
 find_package(Eigen3 REQUIRED)
 include_directories(${EIGEN3_INCLUDE_DIR})
 
-SETUP_PROJECT()
+SETUP_HPP_PROJECT()
 
 OPTION (BUILD_PYTHON_INTERFACE "Build the python binding" ON)
 IF(BUILD_PYTHON_INTERFACE)
-# search for python
-	FINDPYTHON(2.7 REQUIRED)
-	find_package( PythonLibs 2.7 REQUIRED )
-	include_directories( ${PYTHON_INCLUDE_DIRS} )
+  # search for python
+  FINDPYTHON(2.7 REQUIRED)
+  find_package( PythonLibs 2.7 REQUIRED )
+  include_directories( ${PYTHON_INCLUDE_DIRS} )
 
-	find_package( Boost COMPONENTS python REQUIRED )
-	include_directories( ${Boost_INCLUDE_DIR} )
+  find_package( Boost COMPONENTS python REQUIRED )
+  include_directories( ${Boost_INCLUDE_DIR} )
 
-	add_subdirectory (python)
-
+  add_subdirectory (python)
 ENDIF(BUILD_PYTHON_INTERFACE)
 
 
 ADD_SUBDIRECTORY(include/hpp/spline)
 ADD_SUBDIRECTORY(tests)
 
-SETUP_PROJECT_FINALIZE()
+SETUP_HPP_PROJECT_FINALIZE()

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -1,99 +1,108 @@
+#!/usr/bin/env python
+
+import unittest
+
 from numpy import matrix
 from numpy.linalg import norm
 
 from hpp_spline import bezier, bezier6, curve_constraints, exact_cubic, from_bezier, polynom, spline_deriv_constraint
 
-__EPS = 1e-6
 
-waypoints = matrix([[1., 2., 3.], [4., 5., 6.]]).transpose()
-waypoints6 = matrix([[1., 2., 3., 7., 5., 5.], [4., 5., 6., 4., 5., 6.]]).transpose()
-time_waypoints = matrix([0., 1.]).transpose()
+class TestSpline(unittest.TestCase):
+    def test_spline(self):
+        waypoints = matrix([[1., 2., 3.], [4., 5., 6.]]).transpose()
+        waypoints6 = matrix([[1., 2., 3., 7., 5., 5.], [4., 5., 6., 4., 5., 6.]]).transpose()
+        time_waypoints = matrix([0., 1.]).transpose()
 
-# testing bezier curve
-a = bezier6(waypoints6)
-a = bezier(waypoints, 3.)
+        # testing bezier curve
+        a = bezier6(waypoints6)
+        a = bezier(waypoints, 3.)
 
-assert (a.degree == a.nbWaypoints - 1)
-a.min()
-a.max()
-a(0.4)
-assert ((a.derivate(0.4, 0) == a(0.4)).all())
-a.derivate(0.4, 2)
-a = a.compute_derivate(100)
+        self.assertEqual(a.degree, a.nbWaypoints - 1)
+        a.min()
+        a.max()
+        a(0.4)
+        self.assertTrue((a.derivate(0.4, 0) == a(0.4)).all())
+        a.derivate(0.4, 2)
+        a = a.compute_derivate(100)
 
-prim = a.compute_primitive(1)
+        prim = a.compute_primitive(1)
 
-for i in range(10):
-    t = float(i) / 10.
-    assert (a(t) == prim.derivate(t, 1)).all()
-assert (prim(0) == matrix([0., 0., 0.])).all()
+        for i in range(10):
+            t = float(i) / 10.
+            self.assertTrue((a(t) == prim.derivate(t, 1)).all())
+        self.assertTrue((prim(0) == matrix([0., 0., 0.])).all())
 
-prim = a.compute_primitive(2)
-for i in range(10):
-    t = float(i) / 10.
-    assert (a(t) == prim.derivate(t, 2)).all()
-assert (prim(0) == matrix([0., 0., 0.])).all()
+        prim = a.compute_primitive(2)
+        for i in range(10):
+            t = float(i) / 10.
+            self.assertTrue((a(t) == prim.derivate(t, 2)).all())
+        self.assertTrue((prim(0) == matrix([0., 0., 0.])).all())
 
-waypoints = matrix([[1., 2., 3.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.]]).transpose()
-a0 = bezier(waypoints)
-a1 = bezier(waypoints, 3.)
-prim0 = a0.compute_primitive(1)
-prim1 = a1.compute_primitive(1)
+        waypoints = matrix([[1., 2., 3.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.]]).transpose()
+        a0 = bezier(waypoints)
+        a1 = bezier(waypoints, 3.)
+        prim0 = a0.compute_primitive(1)
+        prim1 = a1.compute_primitive(1)
 
-for i in range(10):
-    t = float(i) / 10.
-    assert norm(a0(t) - a1(3 * t)) < __EPS
-    assert norm(a0.derivate(t, 1) - a1.derivate(3 * t, 1) * 3.) < __EPS
-    assert norm(a0.derivate(t, 2) - a1.derivate(3 * t, 2) * 9.) < __EPS
-    assert norm(prim0(t) - prim1(t * 3) / 3.) < __EPS
-assert (prim(0) == matrix([0., 0., 0.])).all()
+        for i in range(10):
+            t = float(i) / 10.
+            self.assertAlmostEqual(norm(a0(t), a1(3 * t)))
+            self.assertAlmostEqual(norm(a0.derivate(t, 1), a1.derivate(3 * t, 1) * 3.))
+            self.assertAlmostEqual(norm(a0.derivate(t, 2), a1.derivate(3 * t, 2) * 9.))
+            self.assertAlmostEqual(norm(prim0(t), prim1(t * 3) / 3.))
+        self.assertTrue((prim(0) == matrix([0., 0., 0.])).all())
 
-# testing bezier with constraints
-c = curve_constraints()
-c.init_vel = matrix([0., 1., 1.]).transpose()
-c.end_vel = matrix([0., 1., 1.]).transpose()
-c.init_acc = matrix([0., 1., -1.]).transpose()
-c.end_acc = matrix([0., 100., 1.]).transpose()
+        # testing bezier with constraints
+        c = curve_constraints()
+        c.init_vel = matrix([0., 1., 1.]).transpose()
+        c.end_vel = matrix([0., 1., 1.]).transpose()
+        c.init_acc = matrix([0., 1., -1.]).transpose()
+        c.end_acc = matrix([0., 100., 1.]).transpose()
 
-waypoints = matrix([[1., 2., 3.], [4., 5., 6.]]).transpose()
-a = bezier(waypoints, c)
-assert norm(a.derivate(0, 1) - c.init_vel) < 1e-10
-assert norm(a.derivate(1, 2) - c.end_acc) < 1e-10
+        waypoints = matrix([[1., 2., 3.], [4., 5., 6.]]).transpose()
+        a = bezier(waypoints, c)
+        self.assertAlmostEqual(norm(a.derivate(0, 1), c.init_vel))
+        self.assertAlmostEqual(norm(a.derivate(1, 2), c.end_acc))
 
-# testing polynom function
-a = polynom(waypoints)
-a = polynom(waypoints, -1., 3.)
-a.min()
-a.max()
-a(0.4)
-assert ((a.derivate(0.4, 0) == a(0.4)).all())
-a.derivate(0.4, 2)
+        # testing polynom function
+        a = polynom(waypoints)
+        a = polynom(waypoints, -1., 3.)
+        a.min()
+        a.max()
+        a(0.4)
+        self.assertTrue((a.derivate(0.4, 0) == a(0.4)).all())
+        a.derivate(0.4, 2)
 
-# testing exact_cubic function
-a = exact_cubic(waypoints, time_waypoints)
-a.min()
-a.max()
-a(0.4)
-assert ((a.derivate(0.4, 0) == a(0.4)).all())
-a.derivate(0.4, 2)
+        # testing exact_cubic function
+        a = exact_cubic(waypoints, time_waypoints)
+        a.min()
+        a.max()
+        a(0.4)
+        self.assertTrue((a.derivate(0.4, 0) == a(0.4)).all())
+        a.derivate(0.4, 2)
 
-# testing spline_deriv_constraints
-c = curve_constraints()
-c.init_vel
-c.end_vel
-c.init_acc
-c.end_acc
+        # testing spline_deriv_constraints
+        c = curve_constraints()
+        c.init_vel
+        c.end_vel
+        c.init_acc
+        c.end_acc
 
-c.init_vel = matrix([0., 1., 1.]).transpose()
-c.end_vel = matrix([0., 1., 1.]).transpose()
-c.init_acc = matrix([0., 1., 1.]).transpose()
-c.end_acc = matrix([0., 1., 1.]).transpose()
+        c.init_vel = matrix([0., 1., 1.]).transpose()
+        c.end_vel = matrix([0., 1., 1.]).transpose()
+        c.init_acc = matrix([0., 1., 1.]).transpose()
+        c.end_acc = matrix([0., 1., 1.]).transpose()
 
-a = spline_deriv_constraint(waypoints, time_waypoints)
-a = spline_deriv_constraint(waypoints, time_waypoints, c)
+        a = spline_deriv_constraint(waypoints, time_waypoints)
+        a = spline_deriv_constraint(waypoints, time_waypoints, c)
 
-# converting bezier to polynom
+        # converting bezier to polynom
 
-a = bezier(waypoints)
-a_pol = from_bezier(a)
-assert norm(a(0.3) - a_pol(0.3)) < __EPS
+        a = bezier(waypoints)
+        a_pol = from_bezier(a)
+        self.assertAlmostEqual(norm(a(0.3), a_pol(0.3)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -4,6 +4,7 @@ import unittest
 
 from numpy import matrix
 from numpy.linalg import norm
+from numpy.testing import assert_allclose
 
 from hpp_spline import bezier, bezier6, curve_constraints, exact_cubic, from_bezier, polynom, spline_deriv_constraint
 
@@ -22,7 +23,7 @@ class TestSpline(unittest.TestCase):
         a.min()
         a.max()
         a(0.4)
-        self.assertTrue((a.derivate(0.4, 0) == a(0.4)).all())
+        assert_allclose(a.derivate(0.4, 0), a(0.4))
         a.derivate(0.4, 2)
         a = a.compute_derivate(100)
 
@@ -30,14 +31,14 @@ class TestSpline(unittest.TestCase):
 
         for i in range(10):
             t = float(i) / 10.
-            self.assertTrue((a(t) == prim.derivate(t, 1)).all())
-        self.assertTrue((prim(0) == matrix([0., 0., 0.])).all())
+            assert_allclose(a(t), prim.derivate(t, 1))
+        assert_allclose(prim(0), matrix([0., 0., 0.]).T)
 
         prim = a.compute_primitive(2)
         for i in range(10):
             t = float(i) / 10.
-            self.assertTrue((a(t) == prim.derivate(t, 2)).all())
-        self.assertTrue((prim(0) == matrix([0., 0., 0.])).all())
+            assert_allclose(a(t), prim.derivate(t, 2))
+        assert_allclose(prim(0), matrix([0., 0., 0.]).T)
 
         waypoints = matrix([[1., 2., 3.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.]]).T
         a0 = bezier(waypoints)
@@ -47,11 +48,13 @@ class TestSpline(unittest.TestCase):
 
         for i in range(10):
             t = float(i) / 10.
-            self.assertAlmostEqual(norm(a0(t) - a1(3 * t)), 0)
-            self.assertAlmostEqual(norm(a0.derivate(t, 1) - a1.derivate(3 * t, 1) * 3.), 0)
-            self.assertAlmostEqual(norm(a0.derivate(t, 2) - a1.derivate(3 * t, 2) * 9.), 0)
-            self.assertAlmostEqual(norm(prim0(t) - prim1(t * 3) / 3.), 0)
-        self.assertTrue((prim(0) == matrix([0., 0., 0.]).T).all())
+            assert_allclose(a0(t), a1(3 * t))
+            assert_allclose(a0.derivate(t, 1), a1.derivate(3 * t, 1) * 3.)
+            assert_allclose(a0.derivate(t, 2), a1.derivate(3 * t, 2) * 9.)
+            assert_allclose(prim0(t), prim1(t * 3) / 3.)
+        assert_allclose(prim(0), matrix([0., 0., 0.]).T)
+        with self.assertRaises(AssertionError):
+            assert_allclose(prim(0), matrix([0., 0., 0.]))
 
         # testing bezier with constraints
         c = curve_constraints()
@@ -62,8 +65,8 @@ class TestSpline(unittest.TestCase):
 
         waypoints = matrix([[1., 2., 3.], [4., 5., 6.]]).T
         a = bezier(waypoints, c)
-        self.assertAlmostEqual(norm(a.derivate(0, 1) - c.init_vel), 0)
-        self.assertAlmostEqual(norm(a.derivate(1, 2) - c.end_acc), 0)
+        assert_allclose(a.derivate(0, 1), c.init_vel)
+        assert_allclose(a.derivate(1, 2), c.end_acc)
 
         # testing polynom function
         a = polynom(waypoints)
@@ -71,7 +74,7 @@ class TestSpline(unittest.TestCase):
         a.min()
         a.max()
         a(0.4)
-        self.assertTrue((a.derivate(0.4, 0) == a(0.4)).all())
+        assert_allclose(a.derivate(0.4, 0), a(0.4))
         a.derivate(0.4, 2)
 
         # testing exact_cubic function
@@ -79,7 +82,7 @@ class TestSpline(unittest.TestCase):
         a.min()
         a.max()
         a(0.4)
-        self.assertTrue((a.derivate(0.4, 0) == a(0.4)).all())
+        assert_allclose(a.derivate(0.4, 0), a(0.4))
         a.derivate(0.4, 2)
 
         # testing spline_deriv_constraints
@@ -101,7 +104,7 @@ class TestSpline(unittest.TestCase):
 
         a = bezier(waypoints)
         a_pol = from_bezier(a)
-        self.assertAlmostEqual(norm(a(0.3) - a_pol(0.3)), 0)
+        assert_allclose(a(0.3), a_pol(0.3))
 
 
 if __name__ == '__main__':

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -10,9 +10,9 @@ from hpp_spline import bezier, bezier6, curve_constraints, exact_cubic, from_bez
 
 class TestSpline(unittest.TestCase):
     def test_spline(self):
-        waypoints = matrix([[1., 2., 3.], [4., 5., 6.]]).transpose()
-        waypoints6 = matrix([[1., 2., 3., 7., 5., 5.], [4., 5., 6., 4., 5., 6.]]).transpose()
-        time_waypoints = matrix([0., 1.]).transpose()
+        waypoints = matrix([[1., 2., 3.], [4., 5., 6.]]).T
+        waypoints6 = matrix([[1., 2., 3., 7., 5., 5.], [4., 5., 6., 4., 5., 6.]]).T
+        time_waypoints = matrix([0., 1.]).T
 
         # testing bezier curve
         a = bezier6(waypoints6)
@@ -39,7 +39,7 @@ class TestSpline(unittest.TestCase):
             self.assertTrue((a(t) == prim.derivate(t, 2)).all())
         self.assertTrue((prim(0) == matrix([0., 0., 0.])).all())
 
-        waypoints = matrix([[1., 2., 3.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.]]).transpose()
+        waypoints = matrix([[1., 2., 3.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.]]).T
         a0 = bezier(waypoints)
         a1 = bezier(waypoints, 3.)
         prim0 = a0.compute_primitive(1)
@@ -47,23 +47,23 @@ class TestSpline(unittest.TestCase):
 
         for i in range(10):
             t = float(i) / 10.
-            self.assertAlmostEqual(norm(a0(t), a1(3 * t)))
-            self.assertAlmostEqual(norm(a0.derivate(t, 1), a1.derivate(3 * t, 1) * 3.))
-            self.assertAlmostEqual(norm(a0.derivate(t, 2), a1.derivate(3 * t, 2) * 9.))
-            self.assertAlmostEqual(norm(prim0(t), prim1(t * 3) / 3.))
-        self.assertTrue((prim(0) == matrix([0., 0., 0.])).all())
+            self.assertAlmostEqual(norm(a0(t) - a1(3 * t)), 0)
+            self.assertAlmostEqual(norm(a0.derivate(t, 1) - a1.derivate(3 * t, 1) * 3.), 0)
+            self.assertAlmostEqual(norm(a0.derivate(t, 2) - a1.derivate(3 * t, 2) * 9.), 0)
+            self.assertAlmostEqual(norm(prim0(t) - prim1(t * 3) / 3.), 0)
+        self.assertTrue((prim(0) == matrix([0., 0., 0.]).T).all())
 
         # testing bezier with constraints
         c = curve_constraints()
-        c.init_vel = matrix([0., 1., 1.]).transpose()
-        c.end_vel = matrix([0., 1., 1.]).transpose()
-        c.init_acc = matrix([0., 1., -1.]).transpose()
-        c.end_acc = matrix([0., 100., 1.]).transpose()
+        c.init_vel = matrix([0., 1., 1.]).T
+        c.end_vel = matrix([0., 1., 1.]).T
+        c.init_acc = matrix([0., 1., -1.]).T
+        c.end_acc = matrix([0., 100., 1.]).T
 
-        waypoints = matrix([[1., 2., 3.], [4., 5., 6.]]).transpose()
+        waypoints = matrix([[1., 2., 3.], [4., 5., 6.]]).T
         a = bezier(waypoints, c)
-        self.assertAlmostEqual(norm(a.derivate(0, 1), c.init_vel))
-        self.assertAlmostEqual(norm(a.derivate(1, 2), c.end_acc))
+        self.assertAlmostEqual(norm(a.derivate(0, 1) - c.init_vel), 0)
+        self.assertAlmostEqual(norm(a.derivate(1, 2) - c.end_acc), 0)
 
         # testing polynom function
         a = polynom(waypoints)
@@ -89,10 +89,10 @@ class TestSpline(unittest.TestCase):
         c.init_acc
         c.end_acc
 
-        c.init_vel = matrix([0., 1., 1.]).transpose()
-        c.end_vel = matrix([0., 1., 1.]).transpose()
-        c.init_acc = matrix([0., 1., 1.]).transpose()
-        c.end_acc = matrix([0., 1., 1.]).transpose()
+        c.init_vel = matrix([0., 1., 1.]).T
+        c.end_vel = matrix([0., 1., 1.]).T
+        c.init_acc = matrix([0., 1., 1.]).T
+        c.end_acc = matrix([0., 1., 1.]).T
 
         a = spline_deriv_constraint(waypoints, time_waypoints)
         a = spline_deriv_constraint(waypoints, time_waypoints, c)
@@ -101,7 +101,7 @@ class TestSpline(unittest.TestCase):
 
         a = bezier(waypoints)
         a_pol = from_bezier(a)
-        self.assertAlmostEqual(norm(a(0.3), a_pol(0.3)))
+        self.assertAlmostEqual(norm(a(0.3) - a_pol(0.3)), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi,

I found that the python unit tests are written with bare `assert`. But those asserts can be ignored by the python interpreter: https://docs.python.org/2.7/reference/simple_stmts.html#grammar-token-assert-stmt

On the current state of this project, launching `ctest` shows that all tests are passing, while using `make test` shows that the python tests are failing.

Therefore, I rewrote the test using the unittest module from the standard library.

Now, it's clear that tests don't pass:
```

test 1
    Start 1: python-spline

1: Test command: /usr/bin/python2.7 "/local/users/gsaurel/humanoid-path-planner/hpp-spline/python/test/test.py"
1: Environment variables: 
1:  PYTHONPATH=/local/users/gsaurel/humanoid-path-planner/hpp-spline/build/python
1:  /local/users/gsaurel/humanoid-path-planner/hpp-spline/build/python
1: Test timeout computed to be: 9.99988e+06
1: F
1: ======================================================================
1: FAIL: test_spline (__main__.TestSpline)
1: ----------------------------------------------------------------------
1: Traceback (most recent call last):
1:   File "/local/users/gsaurel/humanoid-path-planner/hpp-spline/python/test/test.py", line 33, in test_spline
1:     self.assertTrue((a(t) == prim.derivate(t, 1)).all())
1: AssertionError: False is not true
1: 
1: ----------------------------------------------------------------------
1: Ran 1 test in 0.001s
1: 
1: FAILED (failures=1)
1/2 Test #1: python-spline ....................***Failed    0.06 sec
```

 While here, update the CMake submodule and its use, as its current version fails on 18.04